### PR TITLE
punchlist of style tweaks

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,7 +7,14 @@ module.exports = {
   plugins: [
     `gatsby-plugin-react-helmet`,
     `gatsby-transformer-sharp`,
-    `gatsby-plugin-sharp`,
+    {
+      resolve: `gatsby-plugin-sharp`,
+      options: {
+        useMozJpeg: false,
+        defaultQuality: 30,
+        cropFocus: `CENTER`,
+      },
+    },
     `gatsby-plugin-netlify-cms`,
     `gatsby-transformer-json`,
     {

--- a/src/components/bootstrap-overrides.css
+++ b/src/components/bootstrap-overrides.css
@@ -2,20 +2,20 @@
   border: none;
 }
 .partners-section-header {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #64c5b4 32.08%),
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #2cd0af 32.08%),
     #ffffff;
 }
 .partners-container {
-  background-color: #64c5b4;
+  background-color: #2cd0af;
 }
 .partners {
   text-align: left;
   width: 520px;
   border: none;
-  background-color: #64c5b4;
+  background-color: #2cd0af;
 }
 .partners-card {
-  background-color: #64c5b4;
+  background-color: #2cd0af;
   color: white;
   text-align: left;
 }
@@ -81,4 +81,8 @@
   font-size: 14px;
   line-height: 16px;
   color: #ffffff;
+}
+
+section:last-child {
+  margin-bottom: 150px;
 }

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -16,7 +16,7 @@ const Header = () => {
         site_title_image {
           childImageSharp {
             fluid {
-              ...GatsbyImageSharpFluid
+              ...GatsbyImageSharpFluid_withWebp_tracedSVG
             }
           }
         }

--- a/src/components/our-vision-story-blocks.js
+++ b/src/components/our-vision-story-blocks.js
@@ -30,8 +30,10 @@ const OurVisionStoryBlocks = () => {
         <StoryBlock
           imageSource={node.image.childImageSharp.fluid}
           altText={node.altText && node.altText}
+          description={node.description && node.description}
           fullText={node.full_text && node.full_text}
-          imageRight={index % 2}
+          imageRight={index % 2 ? false : true}
+          key={index}
         />
       ))}
     </div>

--- a/src/components/projects.js
+++ b/src/components/projects.js
@@ -17,7 +17,7 @@ const Projects = () => {
           image {
             childImageSharp {
               fluid {
-                ...GatsbyImageSharpFluid
+                ...GatsbyImageSharpFluid_withWebp_tracedSVG
               }
             }
           }
@@ -28,7 +28,7 @@ const Projects = () => {
   const projectsData = projectsQuery.contentJson.projects
   return (
     <div className="partners-container">
-      {projectsData.map(node => (
+      {projectsData.map((node, index) => (
         <Project
           image={node.image.childImageSharp.fluid}
           title={node.title}
@@ -37,6 +37,7 @@ const Projects = () => {
           description={node.description}
           additionalDescription={node.additional_description}
           callToAction={node.call_to_action}
+          key={index}
         />
       ))}
     </div>

--- a/src/components/section-header.js
+++ b/src/components/section-header.js
@@ -1,13 +1,13 @@
-import { Link } from "gatsby"
-import PropTypes from "prop-types"
-import React from "react"
-import Image from "react-bootstrap/Image"
-import Container from "react-bootstrap/Container"
-import Img from "gatsby-image"
+import { Link } from 'gatsby'
+import PropTypes from 'prop-types'
+import React from 'react'
+import Image from 'react-bootstrap/Image'
+import Container from 'react-bootstrap/Container'
+import Img from 'gatsby-image'
 
 const SectionHeader = ({ imageSource, altText }) => (
   <header>
-    <Container>
+    <Container className="w-45">
       <div>
         <Img fluid={imageSource} alt={altText} className="img-responsive" />
       </div>

--- a/src/components/section-header.js
+++ b/src/components/section-header.js
@@ -7,7 +7,7 @@ import Img from 'gatsby-image'
 
 const SectionHeader = ({ imageSource, altText }) => (
   <header>
-    <Container className="w-45">
+    <Container>
       <div>
         <Img fluid={imageSource} alt={altText} className="img-responsive" />
       </div>

--- a/src/components/story-block.js
+++ b/src/components/story-block.js
@@ -14,14 +14,16 @@ const StoryBlock = ({
   imageRight = false,
 }) => (
   <section>
-    <Container>
+    <Container className="my-1">
       <Row>
         <Col sm={{ span: '6', order: `${imageRight ? 'last' : 'first'} ` }}>
           <Img fluid={imageSource} alt={altText} />
         </Col>
         <Col sm={6}>
-          {description}
-          <ReactMarkdown source={fullText} />
+          <p className="font-weight-bold">{description}</p>
+          <div className="pb-5">
+            <ReactMarkdown source={fullText} />
+          </div>
         </Col>
       </Row>
     </Container>

--- a/src/components/story-blocks.js
+++ b/src/components/story-blocks.js
@@ -15,7 +15,7 @@ const StoryBlocks = () => {
           image {
             childImageSharp {
               fluid {
-                ...GatsbyImageSharpFluid
+                ...GatsbyImageSharpFluid_withWebp_tracedSVG
               }
             }
           }
@@ -25,13 +25,14 @@ const StoryBlocks = () => {
   `)
   const storyData = storysQuery.contentJson.stories
   return (
-    <div>
+    <div className="last-child-margin">
       {storyData.map((node, index) => (
         <StoryBlock
           imageSource={node.image.childImageSharp.fluid}
           altText={node.altText && node.altText}
           description={node.description && node.description}
-          imageRight={index % 2}
+          imageRight={index % 2 ? true : false}
+          key={index}
         />
       ))}
     </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,14 +20,14 @@ const IndexPage = () => {
       ) {
         childImageSharp {
           fluid {
-            ...GatsbyImageSharpFluid
+            ...GatsbyImageSharpFluid_withWebp_tracedSVG
           }
         }
       }
       vision: file(relativePath: { eq: "images/our-vision.png" }) {
         childImageSharp {
           fluid {
-            ...GatsbyImageSharpFluid
+            ...GatsbyImageSharpFluid_withWebp_tracedSVG
           }
         }
       }
@@ -36,7 +36,7 @@ const IndexPage = () => {
       ) {
         childImageSharp {
           fluid {
-            ...GatsbyImageSharpFluid
+            ...GatsbyImageSharpFluid_withWebp_tracedSVG
           }
         }
       }


### PR DESCRIPTION
This PR does a plethora of things: 
* makes some tweaks to image optimization. I set quality lower, which should give us smaller sizes and faster loads, and should be fine for our simple the images are. i also changed the preview to be a traced SVG which gives us a  better loading effect, and had gatsby use WebP where it can. Nice!
* did some style corrections, based off client feedback